### PR TITLE
Falten dades llegint S12 de Concentrador 

### DIFF
--- a/switching/messages/TG.py
+++ b/switching/messages/TG.py
@@ -176,7 +176,10 @@ class Values(object):
             if self.version == '3.1c':
                 fw_up_to_field = 'TimeOutMeterFwU'
             else:
-                fw_up_to_field = 'TimeOutPrimeFwU' 
+                fw_up_to_field = 'TimeOutPrimeFwU'
+            #Els concentradors current retornen el camp IPftp1
+            rpt_ftp_ip_address = (S12_header.get('IPftp', False)
+                                  or S12_header.get('IPftp1'))
             vals = {
                 'date': timestamp,
                 'model': S12_header.get('Mod'),
@@ -205,7 +208,7 @@ class Values(object):
                 'stg_ws_ip_address': S12_header.get('IPstg'),
                 'stg_ws_password': S12_header.get('stgPwd'),
                 'ntp_ip_address': S12_header.get('IPNTP'),
-                'rpt_ftp_ip_address': S12_header.get('IPftp'),
+                'rpt_ftp_ip_address': rpt_ftp_ip_address,
                 'rpt_ftp_user': S12_header.get('FTPUserReport'),
                 'rpt_ftp_password': S12_header.get('FTPPwdReport'),
                 'fwdcup_ftp_ip_address': S12_header.get('IPftpDCUpg'),


### PR DESCRIPTION
Hi ha alguns camps de l'S12 que no es llegeixen, p.e. el camp IPftp1 de l'XML hauria de correspondre amb la ip de l'FTP de lectures.

Adjunto XML:

``` xml
<Report IdPet="0" IdRpt="S12" Version="3.1">
    <Cnc Id="CUR79DE402017">
        <S12 Fh="20130603113942000S" Mod="9710" Af="2011" Te="concentrator" Vf="2012.1.1" VfComm="1.2.4c_RELEASE.6240" Pro="ISDIP" Com="" Bat="0" ipDhcp="N" ipCom="192.168.1.2" ipMask="255.255.255.0" ipGtw="192.168.1.100" Macplc="00:80:E1:01:42:C1" ipLoc="192.168.1.1" Pse="57600" IPstg="" URLstg="" IPftp1="10.27.5.6" IPNTP="10.27.3.4" RetryFtp="5" TimeBetwFtp="60" ResetMsg="Y" TimeRetryInterval="300" FTPUserReport="prohida" FTPPwdReport="********************" UserftpDCUpg="DCUPGRADE" PwdftpDCUpg="***********" UserftpMeterUpg="CNTUPGRADE" PwdftpMeterUpg="***********" ReportFormat="0" Priority="Y" DCPwdAdm="******" DCPwdRead="*******" stgPwd="" S26Content="Pimp;AIa;L1v" PortWS="8080" IPftpDCUpg="" IPftpMeterUpg="" Slave1="" Slave2="" Slave3="" TimeOutPrimeFwU="0" SyncMeter="Y" TimeDev="5" TimeDevOver="600" NumMeters="0" TimeSendReq="600" TimeDisconMeter="300" RetryDisconMeter="3" MeterRegData="010000600100FF02010000600101FF02010000600102FF02" ValuesCheckDelay="3" IPftpCycles="" UserftpCycles="trazas" PwdftpCycles="********" DestDirCycles="/trazas"/>
    </Cnc>
</Report>
```
