### PR TITLE
IMP ModoControlPotencia a CondicionesContractuales

### DIFF
--- a/switching/input/messages/C1.py
+++ b/switching/input/messages/C1.py
@@ -1032,6 +1032,15 @@ class Condicions(object):
             pot.append((int(i.get('Periodo')), int(i.text)))
         return sorted(pot)
 
+    @property
+    def control_potencia(self):
+        control_potencia = ''
+        try:
+            control_potencia = self.cond.ModoControlPotencia.text
+        except AttributeError:
+            pass
+        return control_potencia
+
 
 class Rebuig(object):
     """Classe Rebuig"""

--- a/switching/output/messages/sw_c1.py
+++ b/switching/output/messages/sw_c1.py
@@ -95,13 +95,15 @@ class PotenciasContratadas(XmlModel):
 
 
 class CondicionesContractuales(XmlModel):
-    _sort_order = ('condicions', 'tarifa', 'periodicidad_facturacion', 'potencies')
+    _sort_order = ('condicions', 'tarifa', 'periodicidad_facturacion',
+                   'potencies', 'control_potencia')
 
     def __init__(self):
         self.condicions = XmlField('CondicionesContractuales')
         self.tarifa = XmlField('TarifaATR')
         self.periodicidad_facturacion = XmlField('PeriodicidadFacturacion')
         self.potencies = PotenciasContratadas()
+        self.control_potencia = XmlField('ModoControlPotencia')
         super(CondicionesContractuales, self).\
                              __init__('CondicionesContractuales', 'condicions')
 


### PR DESCRIPTION
- `ModoControlPotencia` és una dada opcional que indica si la potència s'ha de
  facturar per maxímetre o ICP
- Al generar el xml, afegim aquesta dada
- La llegim de l'xml
