### PR TITLE
FIX ordre incorrecte Contacto a tags Contrato

### DIFF
--- a/switching/output/messages/sw_c1.py
+++ b/switching/output/messages/sw_c1.py
@@ -120,8 +120,8 @@ class Contacto(XmlModel):
 
 class Contrato(XmlModel):
     _sort_order = ('contrato', 'idcontrato', 'duracion', 'fechafin',
-                   'tipo', 'condiciones', 'direccion', 'consumoanual',
-                   'contacto', 'tipoactivacion', 'fechaactivacion',)
+                   'tipo', 'condiciones', 'consumoanual', 'contacto',
+                   'direccion', 'tipoactivacion', 'fechaactivacion',)
 
     def __init__(self, tag_tipo='TipoContratoATR'):
         self.contrato = XmlField('Contrato')


### PR DESCRIPTION
- L'ordre de `Contacto` dins de Contrato no era correcte i el fitxer no
  validava. Dirección també estava mal ordenat.
