### PR TITLE
NEW F1's amb IBAN en comptes de CCC

### DIFF
--- a/switching/data/Facturacion.xsd
+++ b/switching/data/Facturacion.xsd
@@ -21,6 +21,8 @@
 -Se añade una ocurrencia al campo IVAIGICreducido
 			2012.07.18
 -Se añade una ocurrencia al campo IVA
+			Version X.X OCSUM 2014.05.22
+-Se modifican los campos para que la cuenta bancaria sea un sólo campo llamado IBAN tipo X34
 
 		</xs:documentation>
 	</xs:annotation>
@@ -805,7 +807,7 @@
 								<xs:documentation>Fecha teorica de pago </xs:documentation>
 							</xs:annotation>
 						</xs:element>
-						<xs:element name="CuentaBancaria" type="CuentaBancaria" minOccurs="0"/>
+						<xs:element name="IBAN" type="X34" minOccurs="0"/>
 						<xs:element name="IdRemesa">
 							<xs:annotation>
 								<xs:documentation>identificacion remesa o agrupación</xs:documentation>

--- a/switching/data/TiposComplejos.xsd
+++ b/switching/data/TiposComplejos.xsd
@@ -19,6 +19,8 @@
 			Version 3.0 OCSUM 2013.04.26 (RD 1718/2013)
 				Se incluye el tipo de dato complejo "NotificacionCambiosATRDesdeDistribuidor" compuesto por un tipo nuevo sencillo, hace referencia al Proceso D.
 				Se incluye el elemento opcional PeriodicidadFacturacion en el tipo complejo "CondicionesContractualesC", hace referencia al paso 5 del Proceso M1, A3, C1, C2.
+			Version X.X OCSUM 2014.04.01
+			  Se modifican los nodos que contienen CuentaBancaria para que en su lugar contengan IBAN que es un tiposimple X34
 		</xs:documentation>
 	</xs:annotation>
 	<xs:complexType name="IdContrato">
@@ -46,7 +48,7 @@
 			</xs:choice>
 			<xs:element name="TipoContratoATR" type="TipoContrato"/>
 			<xs:element name="DireccionCorrespondencia" type="DireccionCorrespondencia"/>
-			<xs:element name="CuentaBancaria" type="CuentaBancaria" minOccurs="0"/>
+			<xs:element name="IBAN" type="X34" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="ContratoPasoMRAMLTarifa2ConCambios">
@@ -60,7 +62,7 @@
 			<xs:element name="CondicionesContractuales2n" type="CondicionesContractuales2n"/>
 			<xs:element name="Contacto" type="Contacto" minOccurs="0"/>
 			<xs:element name="DireccionCorrespondencia" type="DireccionCorrespondencia"/>
-			<xs:element name="CuentaBancaria" type="CuentaBancaria" minOccurs="0"/>
+			<xs:element name="IBAN" type="X34" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="Direccion">
@@ -305,7 +307,7 @@
 			<xs:element name="ConsumoAnualEstimado" type="Decimal13" minOccurs="0"/>
 			<xs:element name="Contacto" type="Contacto" minOccurs="0"/>
 			<xs:element name="DireccionCorrespondencia" type="DireccionCorrespondencia"/>
-			<xs:element name="CuentaBancaria" type="CuentaBancaria" minOccurs="0"/>
+			<xs:element name="IBAN" type="X34" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="ContratoConModificacion">
@@ -320,7 +322,7 @@
 			<xs:element name="ConsumoAnualEstimado" type="Decimal13" minOccurs="0"/>
 			<xs:element name="Contacto" type="Contacto" minOccurs="0"/>
 			<xs:element name="DireccionCorrespondencia" type="DireccionCorrespondencia"/>
-			<xs:element name="CuentaBancaria" type="CuentaBancaria" minOccurs="0"/>
+			<xs:element name="IBAN" type="X34" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
 	<!-- del tipo C -->

--- a/switching/data/TiposSencillos.xsd
+++ b/switching/data/TiposSencillos.xsd
@@ -23,7 +23,8 @@
 -Se crea el tipo de dato "Periodicidad", hace refencia al paso 1 y 5 del Proceso M1 y al paso 5 de los procesos A3, C1 y C2.
 -Se incluyen los motivos de rechazo 66, 67, 68, 69 y 70 en el tipo de dato CodigoMotivoRechazo.
 -Se modifican los valores del tipo de dato sencillo "TipoContrato", el descriptor del valor 02 pasa de ser "Eventual" a ser "Eventual medido" y se eliminan los valores 04 y 06.
-
+      Version X.X
+-Se incluye el campo X34 para poder utilizar el nuevo campo IBAN de cuentas bancarias de 34 caracteres alfanuméricos
 		</xs:documentation>
 	</xs:annotation>
 	<xs:simpleType name="Decimal1">
@@ -227,6 +228,12 @@
 		<xs:restriction base="xs:string">
 			<xs:minLength value="1"/>
 			<xs:maxLength value="32"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="X34">
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="34"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="X35">

--- a/switching/output/messages/facturacio.py
+++ b/switching/output/messages/facturacio.py
@@ -308,21 +308,9 @@ class FacturaATR(XmlModel):
         super(FacturaATR, self).__init__('FacturaATR', 'factura')
 
 
-class CuentaBancaria(XmlModel):
-    _sort_order = ('ccc', 'banco', 'sucursal', 'digcontrol', 'cuenta')
-
-    def __init__(self):
-        self.ccc = XmlField('CuentaBancaria')
-        self.banco = XmlField('Banco')
-        self.sucursal = XmlField('Sucursal')
-        self.digcontrol = XmlField('DC')
-        self.cuenta = XmlField('Cuenta')
-        super(CuentaBancaria, self).__init__('CuentaBancaria', 'ccc')
-
-
 class RegistroFin(XmlModel):
     _sort_order = ('registro', 'importe', 'sfacturacion', 'scobro', 'totalrec',
-                   'tipomoneda', 'fvalor', 'flimite', 'ccc', 'idremesa')
+                   'tipomoneda', 'fvalor', 'flimite', 'iban', 'idremesa')
 
     def __init__(self):
         self.registro = XmlField('RegistroFin')
@@ -334,7 +322,7 @@ class RegistroFin(XmlModel):
         self.tipomoneda = XmlField('TipoMoneda')
         self.fvalor = XmlField('FechaValor')
         self.flimite = XmlField('FechaLimitePago')
-        self.ccc = CuentaBancaria()
+        self.iban = XmlField('IBAN')
         self.idremesa = XmlField('IdRemesa')
         super(RegistroFin, self).__init__('RegistroFin', 'registro')
 


### PR DESCRIPTION
A partir del 01/08/2014, les distribuidores envíen un camp `IBAN` en comptes de un camp `CuentaCorriente`.
Aquesta modificació fa que no es validin contra la llibreria de switching i les factures no entrin
- Modifiquem els xsd's amb els que publica la CNMC (http://cambiosdesuministrador.cnmc.es/group/cambio-de-suministrador/formatos-consensuados)
- En la generació de F1's utilitza el IBAN
