### PR TITLE
IMP Better dealing of meter when 99 wheels

### DIFF
--- a/switching/input/messages/F1.py
+++ b/switching/input/messages/F1.py
@@ -606,7 +606,11 @@ class FacturaATR(Facturas):
             0
         ))
         if num_ruedas > 0:
-            num_ruedas = 10 ** num_ruedas
+            if num_ruedas == 99:
+                num_ruedas = 10
+            else:
+                num_ruedas = 10 ** num_ruedas
+
         return num_ruedas
 
 

--- a/switching/input/messages/Q1.py
+++ b/switching/input/messages/Q1.py
@@ -143,6 +143,8 @@ class Lectura(object):
 
     @property
     def gir_comptador(self):
+        if self.lectura.NumeroRuedasEnteras.text == '99':
+            return 10
         return (10 ** int(self.lectura.NumeroRuedasEnteras.text))
 
 
@@ -174,6 +176,8 @@ class Comptador(object):
 
     @property
     def gir_comptador(self):
+        if self.obj.Integrador.NumeroRuedasEnteras.text == '99':
+            return 10
         return (10 ** int(self.obj.Integrador.NumeroRuedasEnteras.text))
 
     @property


### PR DESCRIPTION
Certain DSO's sends 99 as `NumeroRuedasEnteras` in F1 and Q1 files resulting in a very high integer and launching and error.

Now we consider 99 as a 1 wheel meter. When measures are loaded, the number of wheels is adjusted to fit the measure automatically.