### PR TITLE
IMP DatosAparato(No)ICP 

### DIFF
--- a/switching/output/messages/mesures.py
+++ b/switching/output/messages/mesures.py
@@ -49,43 +49,41 @@ class Integrador(XmlModel):
         super(Integrador, self).__init__('Integrador', 'integrador')
 
 
-class NoICP(XmlModel):
+class DatosAparato(XmlModel):
 
-    _sort_order = ('noicp', 'periode_fabricacio', 'num_serie',
+    _sort_order = ('datosaparato', 'periode_fabricacio', 'num_serie',
                    'funcio', 'num_integradors', 'constant_energia',
                    'constant_max', 'enters', 'decimals')
 
-    def __init__(self):
-        self.noicp = XmlField('DatosAparatoNoICP')
+    def __init__(self, tagname='DatosAparato'):
+        self.datosaparato = XmlField(tagname)
         self.periode_fabricacio = XmlField('PeriodoFabricacion')
         self.num_serie = XmlField('NumeroSerie')
         self.funcio = XmlField('FuncionAparato')
-        self.num_integradors = XmlField('NumIntegradores', rep=lambda x: '%i' % x)
-        self.constant_energia = XmlField('ConstanteEnergia', rep=lambda x: '%.3f' % x)
-        self.constant_max = XmlField('ConstanteMaximetro', rep=lambda x: '%.3f' % x)
+        self.num_integradors = XmlField(
+            'NumIntegradores', rep=lambda x: '%i' % x
+        )
+        self.constant_energia = XmlField(
+            'ConstanteEnergia', rep=lambda x: '%.3f' % x
+        )
+        self.constant_max = XmlField(
+            'ConstanteMaximetro', rep=lambda x: '%.3f' % x
+        )
         self.enters = XmlField('RuedasEnteras', rep=lambda x: '%i' % x)
         self.decimals = XmlField('RuedasDecimales', rep=lambda x: '%i' % x)
-        super(NoICP, self).__init__('DatosAparatoNoICP', 'noicp')
+        super(DatosAparato, self).__init__(tagname, 'datosaparato')
 
 
-class ICP(XmlModel):
-
-    _sort_order = ('icp', 'periode_fabricacio', 'num_serie',
-                   'funcio', 'num_integradors', 'constant_energia',
-                   'constant_max', 'enters', 'decimals')
+class NoICP(DatosAparato):
 
     def __init__(self):
-        self.icp = XmlField('DatosAparatoICP')
-        self.periode_fabricacio = XmlField('PeriodoFabricacion')
-        self.num_serie = XmlField('NumeroSerie',
-                                  rep=lambda x: x[:10])
-        self.funcio = XmlField('FuncionAparato')
-        self.num_integradors = XmlField('NumIntegradores', rep=lambda x: '%i' % x)
-        self.constant_energia = XmlField('ConstanteEnergia', rep=lambda x: '%.3f' % x)
-        self.constant_max = XmlField('ConstanteMaximetro', rep=lambda x: '%.3f' % x)
-        self.enters = XmlField('RuedasEnteras', rep=lambda x: '%i' % x)
-        self.decimals = XmlField('RuedasDecimales', rep=lambda x: '%i' % x)
-        super(ICP, self).__init__('DatosAparatoICP', 'icp')
+        super(NoICP, self).__init__(tagname='DatosAparatoNoICP')
+
+
+class ICP(DatosAparato):
+
+    def __init__(self):
+        super(ICP, self).__init__(tagname='DatosAparatoICP')
 
 
 class Modelo(XmlModel):

--- a/switching/output/messages/mesures.py
+++ b/switching/output/messages/mesures.py
@@ -60,7 +60,7 @@ class NoICP(XmlModel):
         self.periode_fabricacio = XmlField('PeriodoFabricacion')
         self.num_serie = XmlField('NumeroSerie')
         self.funcio = XmlField('FuncionAparato')
-        self.num_integradors = XmlField('NumIntegradores')
+        self.num_integradors = XmlField('NumIntegradores', rep=lambda x: '%i' % x)
         self.constant_energia = XmlField('ConstanteEnergia', rep=lambda x: '%.3f' % x)
         self.constant_max = XmlField('ConstanteMaximetro', rep=lambda x: '%.3f' % x)
         self.enters = XmlField('RuedasEnteras', rep=lambda x: '%i' % x)
@@ -80,11 +80,11 @@ class ICP(XmlModel):
         self.num_serie = XmlField('NumeroSerie',
                                   rep=lambda x: x[:10])
         self.funcio = XmlField('FuncionAparato')
-        self.num_integradors = XmlField('NumIntegradores')
+        self.num_integradors = XmlField('NumIntegradores', rep=lambda x: '%i' % x)
         self.constant_energia = XmlField('ConstanteEnergia', rep=lambda x: '%.3f' % x)
         self.constant_max = XmlField('ConstanteMaximetro', rep=lambda x: '%.3f' % x)
-        self.enters = XmlField('RuedasEnteras')
-        self.decimals = XmlField('RuedasDecimales')
+        self.enters = XmlField('RuedasEnteras', rep=lambda x: '%i' % x)
+        self.decimals = XmlField('RuedasDecimales', rep=lambda x: '%i' % x)
         super(ICP, self).__init__('DatosAparatoICP', 'icp')
 
 

--- a/tests/data/DatosAparatoConIntegradores.xml
+++ b/tests/data/DatosAparatoConIntegradores.xml
@@ -1,0 +1,10 @@
+<DatosAparato>
+    <PeriodoFabricacion>2015</PeriodoFabricacion>
+    <NumeroSerie>753855</NumeroSerie>
+    <FuncionAparato>M</FuncionAparato>
+    <NumIntegradores>20</NumIntegradores>
+    <ConstanteEnergia>1.000</ConstanteEnergia>
+    <ConstanteMaximetro>1.000</ConstanteMaximetro>
+    <RuedasEnteras>1</RuedasEnteras>
+    <RuedasDecimales>0</RuedasDecimales>
+</DatosAparato>

--- a/tests/data/DatosAparatoICPConIntegradores.xml
+++ b/tests/data/DatosAparatoICPConIntegradores.xml
@@ -1,0 +1,10 @@
+<DatosAparatoICP>
+    <PeriodoFabricacion>2015</PeriodoFabricacion>
+    <NumeroSerie>753855</NumeroSerie>
+    <FuncionAparato>M</FuncionAparato>
+    <NumIntegradores>20</NumIntegradores>
+    <ConstanteEnergia>1.000</ConstanteEnergia>
+    <ConstanteMaximetro>1.000</ConstanteMaximetro>
+    <RuedasEnteras>1</RuedasEnteras>
+    <RuedasDecimales>0</RuedasDecimales>
+</DatosAparatoICP>

--- a/tests/data/DatosAparatoICPSinIntegradores.xml
+++ b/tests/data/DatosAparatoICPSinIntegradores.xml
@@ -1,0 +1,10 @@
+<DatosAparatoICP>
+    <PeriodoFabricacion>2015</PeriodoFabricacion>
+    <NumeroSerie>753855</NumeroSerie>
+    <FuncionAparato>M</FuncionAparato>
+    <NumIntegradores>0</NumIntegradores>
+    <ConstanteEnergia>1.000</ConstanteEnergia>
+    <ConstanteMaximetro>1.000</ConstanteMaximetro>
+    <RuedasEnteras>1</RuedasEnteras>
+    <RuedasDecimales>0</RuedasDecimales>
+</DatosAparatoICP>

--- a/tests/data/DatosAparatoNoICPConIntegradores.xml
+++ b/tests/data/DatosAparatoNoICPConIntegradores.xml
@@ -1,0 +1,10 @@
+<DatosAparatoNoICP>
+    <PeriodoFabricacion>2015</PeriodoFabricacion>
+    <NumeroSerie>753855</NumeroSerie>
+    <FuncionAparato>M</FuncionAparato>
+    <NumIntegradores>20</NumIntegradores>
+    <ConstanteEnergia>1.000</ConstanteEnergia>
+    <ConstanteMaximetro>1.000</ConstanteMaximetro>
+    <RuedasEnteras>1</RuedasEnteras>
+    <RuedasDecimales>0</RuedasDecimales>
+</DatosAparatoNoICP>

--- a/tests/data/DatosAparatoNoICPSinIntegradores.xml
+++ b/tests/data/DatosAparatoNoICPSinIntegradores.xml
@@ -1,0 +1,10 @@
+<DatosAparatoNoICP>
+    <PeriodoFabricacion>2015</PeriodoFabricacion>
+    <NumeroSerie>753855</NumeroSerie>
+    <FuncionAparato>M</FuncionAparato>
+    <NumIntegradores>0</NumIntegradores>
+    <ConstanteEnergia>1.000</ConstanteEnergia>
+    <ConstanteMaximetro>1.000</ConstanteMaximetro>
+    <RuedasEnteras>1</RuedasEnteras>
+    <RuedasDecimales>0</RuedasDecimales>
+</DatosAparatoNoICP>

--- a/tests/data/DatosAparatoSinIntegradores.xml
+++ b/tests/data/DatosAparatoSinIntegradores.xml
@@ -1,0 +1,10 @@
+<DatosAparato>
+    <PeriodoFabricacion>2015</PeriodoFabricacion>
+    <NumeroSerie>753855</NumeroSerie>
+    <FuncionAparato>M</FuncionAparato>
+    <NumIntegradores>0</NumIntegradores>
+    <ConstanteEnergia>1.000</ConstanteEnergia>
+    <ConstanteMaximetro>1.000</ConstanteMaximetro>
+    <RuedasEnteras>1</RuedasEnteras>
+    <RuedasDecimales>0</RuedasDecimales>
+</DatosAparato>

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -6,7 +6,7 @@ from switching.output.messages.sw_c1 import (
 )
 from switching.output.messages.sw_c2 import CiePapel, DatosCie, DocTecnica,\
     RegistroDoc, RegistrosDocumento
-from switching.output.messages.mesures import NoICP, ICP
+from switching.output.messages.mesures import NoICP, ICP, DatosAparato
 
 from . import unittest
 import os
@@ -354,6 +354,51 @@ class test_NoICP(unittest.TestCase):
         xml = str(c)
         self.assertXmlEqual(xml, self.loadFile(
             'DatosAparatoNoICPConIntegradores.xml'
+        ))
+
+
+class test_DatosAparato(unittest.TestCase):
+    def loadFile(self, filename):
+        with open(get_data(filename), "r") as f:
+            return f.read()
+
+    def setUp(self):
+        pass
+
+    def test_build_NoIntegradores(self):
+        c = DatosAparato()
+        c.feed({
+            'periode_fabricacio': 2015,
+            'num_serie': '753855',
+            'funcio': 'M',
+            'num_integradors': 0,
+            'constant_energia': 1.0,
+            'constant_max': 1.0,
+            'enters': 1,
+            'decimals': 0,
+        })
+        c.build_tree()
+        xml = str(c)
+        self.assertXmlEqual(xml, self.loadFile(
+            'DatosAparatoSinIntegradores.xml'
+        ))
+
+    def test_build_Integradores(self):
+        c = DatosAparato()
+        c.feed({
+            'periode_fabricacio': 2015,
+            'num_serie': '753855',
+            'funcio': 'M',
+            'num_integradors': 20,
+            'constant_energia': 1.0,
+            'constant_max': 1.0,
+            'enters': 1,
+            'decimals': 0,
+        })
+        c.build_tree()
+        xml = str(c)
+        self.assertXmlEqual(xml, self.loadFile(
+            'DatosAparatoConIntegradores.xml'
         ))
 
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -6,6 +6,8 @@ from switching.output.messages.sw_c1 import (
 )
 from switching.output.messages.sw_c2 import CiePapel, DatosCie, DocTecnica,\
     RegistroDoc, RegistrosDocumento
+from switching.output.messages.mesures import NoICP, ICP
+
 from . import unittest
 import os
 import decimal
@@ -308,6 +310,97 @@ class test_CondicionesContractuales(unittest.TestCase):
         self.assertXmlEqual(
             xml, self.loadFile('CondContractualesMedidaBaja.xml')
         )
+
+
+class test_NoICP(unittest.TestCase):
+    def loadFile(self, filename):
+        with open(get_data(filename), "r") as f:
+            return f.read()
+
+    def setUp(self):
+        pass
+
+    def test_build_NoIntegradores(self):
+        c = NoICP()
+        c.feed({
+            'periode_fabricacio': 2015,
+            'num_serie': '753855',
+            'funcio': 'M',
+            'num_integradors': 0,
+            'constant_energia': 1.0,
+            'constant_max': 1.0,
+            'enters': 1,
+            'decimals': 0,
+        })
+        c.build_tree()
+        xml = str(c)
+        self.assertXmlEqual(xml, self.loadFile(
+            'DatosAparatoNoICPSinIntegradores.xml'
+        ))
+
+    def test_build_Integradores(self):
+        c = NoICP()
+        c.feed({
+            'periode_fabricacio': 2015,
+            'num_serie': '753855',
+            'funcio': 'M',
+            'num_integradors': 20,
+            'constant_energia': 1.0,
+            'constant_max': 1.0,
+            'enters': 1,
+            'decimals': 0,
+        })
+        c.build_tree()
+        xml = str(c)
+        self.assertXmlEqual(xml, self.loadFile(
+            'DatosAparatoNoICPConIntegradores.xml'
+        ))
+
+
+class test_ICP(unittest.TestCase):
+    def loadFile(self, filename):
+        with open(get_data(filename), "r") as f:
+            return f.read()
+
+    def setUp(self):
+        pass
+
+    def test_build_NoIntegradores(self):
+        c = ICP()
+        c.feed({
+            'periode_fabricacio': 2015,
+            'num_serie': '753855',
+            'funcio': 'M',
+            'num_integradors': 0,
+            'constant_energia': 1.0,
+            'constant_max': 1.0,
+            'enters': 1,
+            'decimals': 0,
+        })
+        c.build_tree()
+        xml = str(c)
+        self.assertXmlEqual(xml, self.loadFile(
+            'DatosAparatoICPSinIntegradores.xml'
+        ))
+
+    def test_build_Integradores(self):
+        c = ICP()
+        c.feed({
+            'periode_fabricacio': 2015,
+            'num_serie': '753855',
+            'funcio': 'M',
+            'num_integradors': 20,
+            'constant_energia': 1.0,
+            'constant_max': 1.0,
+            'enters': 1,
+            'decimals': 0,
+        })
+        c.build_tree()
+        xml = str(c)
+        self.assertXmlEqual(xml, self.loadFile(
+            'DatosAparatoICPConIntegradores.xml'
+        ))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
``DatosAparato(No)ICP`` improvements

- [x] Permits empty fields, specially ``NumIntegradores``
- [x] Better implementation for very similar models
- [x] Testing