### PR TITLE
Improvement: No error when missing fields

### DIFF
--- a/switching/input/messages/A3.py
+++ b/switching/input/messages/A3.py
@@ -1,5 +1,6 @@
 
 # -*- coding: utf-8 -*-
+from switching.helpers.funcions import get_rec_attr
 
 from message import Message, except_f1
 import C1, C2
@@ -11,20 +12,32 @@ class A3(Message):
     @property
     def sollicitud(self):
         """Retorna l'objecte Sollicitud"""
-        return C1.Sollicitud(self.obj.PasoMRAMLConCambiosRestoTarifa.\
-                             DatosSolicitud)
+        tree = 'PasoMRAMLConCambiosRestoTarifa.DatosSolicitud'
+        sol = get_rec_attr(self.obj, tree, False)
+        if sol:
+            return C1.Sollicitud(sol)
+        else:
+            return False
 
     @property
     def contracte(self):
         """Retorna l'objecte Contracte"""
-        obj = getattr(self.obj, self.header)
-        return C1.Contracte(obj.Contrato)
+        tree = '{0}.Contrato'.format(self.header)
+        cont = get_rec_attr(self.obj, tree, False)
+        if cont:
+            return C1.Contracte(cont)
+        else:
+            return False
 
     @property
     def client(self):
         """Retorna l'objecte Client"""
-        return C1.Client(self.obj.PasoMRAMLConCambiosRestoTarifa.\
-                         Cliente)
+        tree = 'PasoMRAMLConCambiosRestoTarifa.Cliente'
+        cli = get_rec_attr(self.obj, tree, False)
+        if cli:
+            return C1.Client(cli)
+        else:
+            return False
 
     @property
     def acceptacio(self):

--- a/switching/input/messages/C1.py
+++ b/switching/input/messages/C1.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from message import Message, except_f1
+from switching.helpers.funcions import get_rec_attr
 
 
 class C1(Message):
@@ -10,19 +11,32 @@ class C1(Message):
     @property
     def sollicitud(self):
         """Retorna l'objecte Sollicitud"""
-        return Sollicitud(self.obj.CambiodeComercializadoraSinCambios.\
-                          DatosSolicitud)
+        tree = 'CambiodeComercializadoraSinCambios.DatosSolicitud'
+        sol = get_rec_attr(self.obj, tree, False)
+        if sol:
+            return Sollicitud(sol)
+        else:
+            return False
 
     @property
     def contracte(self):
         """Retorna l'objecte Contracte"""
-        obj = getattr(self.obj, self._header)
-        return Contracte(obj.Contrato)
+        tree = '{0}.Contrato'.format(self._header)
+        cont = get_rec_attr(self.obj, tree, False)
+        if cont:
+            return Contracte(cont)
+        else:
+            return False
 
     @property
     def client(self):
         """Retorna l'objecte Client"""
-        return Client(self.obj.CambiodeComercializadoraSinCambios.Cliente)
+        tree = 'CambiodeComercializadoraSinCambios.Cliente'
+        cli = get_rec_attr(self.obj, tree, False)
+        if cli:
+            return Client(cli)
+        else:
+            return False
 
     @property
     def acceptacio(self):
@@ -849,7 +863,12 @@ class Contracte(object):
     @property
     def condicions(self):
         """Retorna l'objecte Condicions"""
-        return Condicions(self.contracte.CondicionesContractuales)
+        tree = 'CondicionesContractuales'
+        cond = get_rec_attr(self.contracte, tree, False)
+        if cond:
+            return Condicions(cond)
+        else:
+            return False
 
     @property
     def consum_anual(self):
@@ -891,22 +910,20 @@ class Client(object):
 
     @property
     def tipus_identificacio(self):
-        obj = getattr(self.client, self.idfield)
-        return obj.TipoCIFNIF.text
+        tree = '{}.TipoCIFNIF.text'.format(self.idfield)
+        return get_rec_attr(self.client, tree, '')
 
     @property
     def codi_identificacio(self):
-        obj = getattr(self.client, self.idfield)
-        return obj.Identificador.text
+        tree = '{}.Identificador.text'.format(self.idfield)
+        return get_rec_attr(self.client, tree, '')
 
     @property
     def nom(self):
-        nom = ''
         if self.es_persona_juridica:
-            nom = self.client.Nombre.RazonSocial.text
+            return get_rec_attr(self.client, 'Nombre.RazonSocial.text', '')
         else:
-            nom = self.client.Nombre.NombreDePila.text
-        return nom
+            return get_rec_attr(self.client, 'Nombre.NombreDePila.text', '')
 
     @property
     def cognom_1(self):

--- a/switching/input/messages/C2.py
+++ b/switching/input/messages/C2.py
@@ -1,5 +1,6 @@
 
 # -*- coding: utf-8 -*-
+from switching.helpers.funcions import get_rec_attr
 
 from message import Message, except_f1
 import C1
@@ -11,19 +12,32 @@ class C2(Message):
     @property
     def sollicitud(self):
         """Retorna l'objecte Sollicitud"""
-        return C1.Sollicitud(self.obj.CambiodeComercializadoraConCambios.\
-                          DatosSolicitud)
+        tree = 'CambiodeComercializadoraConCambios.DatosSolicitud'
+        sol = get_rec_attr(self.obj, tree, False)
+        if sol:
+            return C1.Sollicitud(sol)
+        else:
+            return False
 
     @property
     def contracte(self):
         """Retorna l'objecte Contracte"""
-        obj = getattr(self.obj, self._header)
-        return C1.Contracte(obj.Contrato)
+        tree = '{0}.Contrato'.format(self.header)
+        cont = get_rec_attr(self.obj, tree, False)
+        if cont:
+            return C1.Contracte(cont)
+        else:
+            return False
 
     @property
     def client(self):
         """Retorna l'objecte Client"""
-        return C1.Client(self.obj.CambiodeComercializadoraConCambios.Cliente)
+        tree = 'CambiodeComercializadoraConCambios.Cliente'
+        cli = get_rec_attr(self.obj, tree, False)
+        if cli:
+            return C1.Client(cli)
+        else:
+            return False
 
     @property
     def acceptacio(self):

--- a/switching/input/messages/M1.py
+++ b/switching/input/messages/M1.py
@@ -1,5 +1,6 @@
 
 # -*- coding: utf-8 -*-
+from switching.helpers.funcions import get_rec_attr
 
 from message import Message, except_f1
 import C1, C2
@@ -11,19 +12,32 @@ class M1(Message):
     @property
     def sollicitud(self):
         """Retorna l'objecte Sollicitud"""
-        return C1.Sollicitud(self.obj.ModificacionDeATR.\
-                          DatosSolicitud)
+        tree = 'ModificacionDeATR.DatosSolicitud'
+        sol = get_rec_attr(self.obj, tree, False)
+        if sol:
+            return C1.Sollicitud(sol)
+        else:
+            return False
 
     @property
     def contracte(self):
         """Retorna l'objecte Contracte"""
-        obj = getattr(self.obj, self._header)
-        return C1.Contracte(obj.Contrato)
+        tree = '{0}.Contrato'.format(self.header)
+        cont = get_rec_attr(self.obj, tree, False)
+        if cont:
+            return C1.Contracte(cont)
+        else:
+            return False
 
     @property
     def client(self):
         """Retorna l'objecte Client"""
-        return C1.Client(self.obj.ModificacionDeATR.Cliente)
+        tree = 'ModificacionDeATR.Cliente'
+        cli = get_rec_attr(self.obj, tree, False)
+        if cli:
+            return C1.Client(cli)
+        else:
+            return False
 
     @property
     def client_sortint(self):

--- a/switching/input/messages/R1.py
+++ b/switching/input/messages/R1.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from switching.helpers.funcions import get_rec_attr
 
 from message import Message
 import C1
@@ -22,7 +23,12 @@ class R1(Message):
     @property
     def sollicitud(self):
         """Retorna l'objecte Sollicitud"""
-        return DatosPasoSollicitud(self.obj.SolicitudReclamacion.DatosSolicitud)
+        tree = 'SolicitudReclamacion.DatosSolicitud'
+        sol = get_rec_attr(self.obj, tree, False)
+        if sol:
+            return DatosPasoSollicitud(sol)
+        else:
+            return False
 
     @property
     def reclamacions(self):
@@ -51,7 +57,8 @@ class R1(Message):
     @property
     def tipus_reclamant(self):
         """Retorna l'objecte Tipo Reclamante"""
-        return self.obj.SolicitudReclamacion.TipoReclamante.text
+        tree = 'SolicitudReclamacion.TipoReclamante.text'
+        return get_rec_attr(self.obj, tree, '')
 
     @property
     def reclamant(self):

--- a/tests/test_switching.py
+++ b/tests/test_switching.py
@@ -585,6 +585,83 @@ class SwitchingC1Test(unittest.TestCase):
         documents = c101_xml.documents
         assert not documents
 
+    def test_accept_no_sollicitud(self):
+        text_to_elim = '    <DatosSolicitud>\n' \
+                       '      <LineaNegocioElectrica>' \
+                                '01</LineaNegocioElectrica>\n' \
+                       '      <SolicitudAdmContractual>' \
+                                'S</SolicitudAdmContractual>\n' \
+                       '      <IndActivacionLectura>' \
+                                'S</IndActivacionLectura>\n' \
+                       '      <FechaPrevistaAccion>' \
+                                '2016-06-06</FechaPrevistaAccion>\n' \
+                       '      <IndSustitutoMandatario>' \
+                                'S</IndSustitutoMandatario>\n' \
+                       '    </DatosSolicitud>\n'
+
+        c101_no_text_xml = C1(self.xml_c101.read().replace(text_to_elim, ''))
+        c101_no_text_xml.set_xsd()
+        c101_no_text_xml.parse_xml(validate=False)
+
+        assert c101_no_text_xml.sollicitud is False
+
+    def test_accept_no_contracte(self):
+        text_to_elim = '    <Contrato>\n' \
+                       '      <IdContrato>\n' \
+                       '        <CodContrato>111111111</CodContrato>\n' \
+                       '      </IdContrato>\n' \
+                       '      <Duracion>12</Duracion>\n' \
+                       '      <TipoContratoATR>01</TipoContratoATR>\n' \
+                       '      <DireccionCorrespondencia>\n' \
+                       '        <Indicador>S</Indicador>\n' \
+                       '      </DireccionCorrespondencia>\n' \
+                       '    </Contrato>\n'
+
+        c101_no_text_xml = C1(self.xml_c101.read().replace(text_to_elim, ''))
+        c101_no_text_xml.set_xsd()
+        c101_no_text_xml.parse_xml(validate=False)
+
+        assert c101_no_text_xml.contracte is False
+
+    def test_accept_no_client(self):
+        text_to_elim = '    <Cliente>\n' \
+                       '      <IdCliente>\n' \
+                       '        <TipoCIFNIF>CI</TipoCIFNIF>\n' \
+                       '        <Identificador>B36385870</Identificador>\n' \
+                       '      </IdCliente>\n' \
+                       '      <Nombre>\n' \
+                       '        <RazonSocial>' \
+                                    'ACC Y COMP DE COCINA MILLAN Y MUÑOZ' \
+                                '</RazonSocial>\n' \
+                       '      </Nombre>\n' \
+                       '      <Telefono>\n' \
+                       '        <PrefijoPais>34</PrefijoPais>\n' \
+                       '        <Numero>666777888</Numero>\n' \
+                       '      </Telefono>\n' \
+                       '    </Cliente>\n'
+
+        c101_no_text_xml = C1(self.xml_c101.read().replace(text_to_elim, ''))
+        c101_no_text_xml.set_xsd()
+        c101_no_text_xml.parse_xml(validate=False)
+
+        assert c101_no_text_xml.client is False
+
+    def test_accept_no_id_type(self):
+        text_to_elim = '        <TipoCIFNIF>CI</TipoCIFNIF>\n'
+
+        c101_no_text_xml = C1(self.xml_c101.read().replace(text_to_elim, ''))
+        c101_no_text_xml.set_xsd()
+        c101_no_text_xml.parse_xml(validate=False)
+
+        assert c101_no_text_xml.client.tipus_identificacio == ''
+
+    def test_accept_no_cond_cont(self):
+        c101_no_text_xml = C1(self.xml_c101)
+        c101_no_text_xml.set_xsd()
+        c101_no_text_xml.parse_xml(validate=False)
+
+        assert c101_no_text_xml.contracte.condicions is False
+
 
 class SwitchingC2Test(unittest.TestCase):
     """test de C2"""
@@ -784,6 +861,109 @@ class SwitchingC2Test(unittest.TestCase):
         pas01.build_tree()
         xml = str(pas01)
         self.assertXmlEqual(xml, self.xml_c201_regdocs.read())
+
+    def test_accept_no_sollicitud(self):
+        text_to_elim = '        <DatosSolicitud>\n' \
+                       '            <LineaNegocioElectrica>' \
+                                        '01</LineaNegocioElectrica>\n' \
+                       '            <SolicitudAdmContractual>' \
+                                        'S</SolicitudAdmContractual>\n' \
+                       '            <IndActivacionLectura>' \
+                                        'S</IndActivacionLectura>\n' \
+                       '            <FechaPrevistaAccion>' \
+                                        '2015-05-27</FechaPrevistaAccion>\n' \
+                       '            <IndSustitutoMandatario>' \
+                                        'S</IndSustitutoMandatario>\n' \
+                       '        </DatosSolicitud>\n'
+
+        c201_no_text_xml = C2(self.xml_c201.read().replace(text_to_elim, ''))
+        c201_no_text_xml.set_xsd()
+        c201_no_text_xml.parse_xml(validate=False)
+
+        assert c201_no_text_xml.sollicitud is False
+
+    def test_accept_no_contracte(self):
+        text_to_elim = '        <Contrato>\n' \
+                       '            <IdContrato>\n' \
+                       '                <CodContrato>' \
+                                            '111111111</CodContrato>\n' \
+                       '            </IdContrato>\n' \
+                       '            <Duracion>12</Duracion>\n' \
+                       '            <TipoContratoATR>01</TipoContratoATR>\n' \
+                       '            <CondicionesContractuales>\n' \
+                       '                <TarifaATR>001</TarifaATR>\n' \
+                       '                <PotenciasContratadas>\n' \
+                       '                    <Potencia Periodo="1">' \
+                                                '4400</Potencia>\n' \
+                       '                </PotenciasContratadas>\n' \
+                       '            </CondicionesContractuales>\n' \
+                       '            <DireccionCorrespondencia>\n' \
+                       '                <Indicador>S</Indicador>\n' \
+                       '            </DireccionCorrespondencia>\n' \
+                       '        </Contrato>\n'
+
+        c201_no_text_xml = C2(self.xml_c201.read().replace(text_to_elim, ''))
+        c201_no_text_xml.set_xsd()
+        c201_no_text_xml.parse_xml(validate=False)
+
+        assert c201_no_text_xml.contracte is False
+
+    def test_accept_no_client(self):
+        text_to_elim = '        <Cliente>\n' \
+                       '            <IdCliente>\n' \
+                       '                <TipoCIFNIF>DN</TipoCIFNIF>\n' \
+                       '                <Identificador>' \
+                                            '11111111H</Identificador>\n' \
+                       '            </IdCliente>\n' \
+                       '            <Nombre>\n' \
+                       '                <NombreDePila>Perico</NombreDePila>\n' \
+                       '                <PrimerApellido>' \
+                                            'Palote</PrimerApellido>\n' \
+                       '                <SegundoApellido>' \
+                                            'Pérez</SegundoApellido>\n' \
+                       '            </Nombre>\n' \
+                       '            <Fax>\n' \
+                       '                <PrefijoPais>34</PrefijoPais>\n' \
+                       '                <Numero>555124124</Numero>\n' \
+                       '            </Fax>\n' \
+                       '            <Telefono>\n' \
+                       '                <PrefijoPais>34</PrefijoPais>\n' \
+                       '                <Numero>555123123</Numero>\n' \
+                       '            </Telefono>\n' \
+                       '            <IndicadorTipoDireccion>' \
+                                        'S</IndicadorTipoDireccion>\n' \
+                       '        </Cliente>\n'
+
+        c201_no_text_xml = C2(self.xml_c201.read().replace(text_to_elim, ''))
+        c201_no_text_xml.set_xsd()
+        c201_no_text_xml.parse_xml(validate=False)
+
+        assert c201_no_text_xml.client is False
+
+    def test_accept_no_id_type(self):
+        text_to_elim = '        <TipoCIFNIF>DN</TipoCIFNIF>\n'
+
+        c201_no_text_xml = C2(self.xml_c201.read().replace(text_to_elim, ''))
+        c201_no_text_xml.set_xsd()
+        c201_no_text_xml.parse_xml(validate=False)
+
+        assert c201_no_text_xml.client.tipus_identificacio == ''
+
+    def test_accept_no_cond_cont(self):
+        text_to_elim = '            <CondicionesContractuales>\n' \
+                       '                <TarifaATR>001</TarifaATR>\n' \
+                       '                <PotenciasContratadas>\n' \
+                       '                    <Potencia Periodo="1">' \
+                                                '4400</Potencia>\n' \
+                       '                </PotenciasContratadas>\n' \
+                       '            </CondicionesContractuales>\n'
+
+        c201_no_text_xml = C2(self.xml_c201.read().replace(text_to_elim, ''))
+        c201_no_text_xml.set_xsd()
+        c201_no_text_xml.parse_xml(validate=False)
+
+        assert c201_no_text_xml.contracte.condicions is False
+
 
 
 class SwitchingA3Test(unittest.TestCase):
@@ -1004,6 +1184,107 @@ class SwitchingA3Test(unittest.TestCase):
         assert contract.codi_contracte == '111111111'
         assert contract.tipus_autoconsum == '2A'
 
+    def test_accept_no_sollicitud(self):
+        text_to_elim = '        <DatosSolicitud>\n' \
+                       '            <LineaNegocioElectrica>' \
+                                        '01</LineaNegocioElectrica>\n' \
+                       '            <SolicitudAdmContractual>' \
+                                        'S</SolicitudAdmContractual>\n' \
+                       '            <IndActivacionLectura>' \
+                                        'N</IndActivacionLectura>\n' \
+                       '            <FechaPrevistaAccion>' \
+                                        '2015-05-18</FechaPrevistaAccion>\n' \
+                       '            <CNAE>9820</CNAE>\n' \
+                       '            <IndSustitutoMandatario>' \
+                                        'S</IndSustitutoMandatario>\n' \
+                       '        </DatosSolicitud>\n'
+
+        a301_no_text_xml = A3(self.xml_a301.read().replace(text_to_elim, ''))
+        a301_no_text_xml.set_xsd()
+        a301_no_text_xml.parse_xml(validate=False)
+
+        assert a301_no_text_xml.sollicitud is False
+
+    def test_accept_no_contracte(self):
+        text_to_elim = '        <Contrato>\n' \
+                       '            <IdContrato>\n' \
+                       '                <CodContrato>111111111</CodContrato>\n' \
+                       '            </IdContrato>\n' \
+                       '            <Duracion>12</Duracion>\n' \
+                       '            <TipoContratoATR>01</TipoContratoATR>\n' \
+                       '            <CondicionesContractuales>\n' \
+                       '                <TarifaATR>001</TarifaATR>\n' \
+                       '                <PotenciasContratadas>\n' \
+                       '                    <Potencia Periodo="1">' \
+                                                '2300</Potencia>\n' \
+                       '                </PotenciasContratadas>\n' \
+                       '            </CondicionesContractuales>\n' \
+                       '            <DireccionCorrespondencia>\n' \
+                       '                <Indicador>S</Indicador>\n' \
+                       '            </DireccionCorrespondencia>\n' \
+                       '        </Contrato>\n'
+
+        a301_no_text_xml = A3(self.xml_a301.read().replace(text_to_elim, ''))
+        a301_no_text_xml.set_xsd()
+        a301_no_text_xml.parse_xml(validate=False)
+
+        assert a301_no_text_xml.contracte is False
+
+    def test_accept_no_client(self):
+        text_to_elim = '        <Cliente>\n' \
+                       '            <IdCliente>\n' \
+                       '                <TipoCIFNIF>DN</TipoCIFNIF>\n' \
+                       '                <Identificador>' \
+                                            '11111111H</Identificador>\n' \
+                       '            </IdCliente>\n' \
+                       '            <Nombre>\n' \
+                       '                <NombreDePila>Perico</NombreDePila>\n' \
+                       '                <PrimerApellido>' \
+                                            'Palote</PrimerApellido>\n' \
+                       '                <SegundoApellido>' \
+                                            'Pérez</SegundoApellido>\n' \
+                       '            </Nombre>\n' \
+                       '            <Fax>\n' \
+                       '                <PrefijoPais>34</PrefijoPais>\n' \
+                       '                <Numero>555124124</Numero>\n' \
+                       '            </Fax>\n' \
+                       '            <Telefono>\n' \
+                       '                <PrefijoPais>34</PrefijoPais>\n' \
+                       '                <Numero>555123123</Numero>\n' \
+                       '            </Telefono>\n' \
+                       '            <IndicadorTipoDireccion>' \
+                                        'S</IndicadorTipoDireccion>\n' \
+                       '        </Cliente>\n'
+
+        a301_no_text_xml = A3(self.xml_a301.read().replace(text_to_elim, ''))
+        a301_no_text_xml.set_xsd()
+        a301_no_text_xml.parse_xml(validate=False)
+
+        assert a301_no_text_xml.client is False
+
+    def test_accept_no_id_type(self):
+        text_to_elim = '        <TipoCIFNIF>DN</TipoCIFNIF>\n'
+
+        a301_no_text_xml = A3(self.xml_a301.read().replace(text_to_elim, ''))
+        a301_no_text_xml.set_xsd()
+        a301_no_text_xml.parse_xml(validate=False)
+
+        assert a301_no_text_xml.client.tipus_identificacio == ''
+
+    def test_accept_no_cond_cont(self):
+        text_to_elim = '            <CondicionesContractuales>\n' \
+                       '                <TarifaATR>001</TarifaATR>\n' \
+                       '                <PotenciasContratadas>\n' \
+                       '                    <Potencia Periodo="1">2300</Potencia>\n' \
+                       '                </PotenciasContratadas>\n' \
+                       '            </CondicionesContractuales>\n'
+
+        a301_no_text_xml = A3(self.xml_a301.read().replace(text_to_elim, ''))
+        a301_no_text_xml.set_xsd()
+        a301_no_text_xml.parse_xml(validate=False)
+
+        assert a301_no_text_xml.contracte.condicions is False
+
 
 class SwitchingM1Test(unittest.TestCase):
     """test de M1"""
@@ -1153,8 +1434,6 @@ class SwitchingM1Test(unittest.TestCase):
         xml = str(pas01)
         self.assertXmlEqual(xml, self.xml_m101_ciepapel.read())
 
-
-
     def test_read_m101_docTec(self):
         self.m101_dt_xml = M1(self.xml_m101_DT)
         self.m101_dt_xml.set_xsd()
@@ -1184,7 +1463,109 @@ class SwitchingM1Test(unittest.TestCase):
         doc_tecnica = self.m101_dt_xml.documentacio_tecnica
         assert not doc_tecnica
 
+    def test_accept_no_sollicitud(self):
+        text_to_elim = '        <DatosSolicitud>\n' \
+                       '            <LineaNegocioElectrica>' \
+                                        '01</LineaNegocioElectrica>\n' \
+                       '            <SolicitudAdmContractual>' \
+                                        'S</SolicitudAdmContractual>\n' \
+                       '            <IndActivacionLectura>' \
+                                        'N</IndActivacionLectura>\n' \
+                       '            <FechaPrevistaAccion>' \
+                                        '2015-05-18</FechaPrevistaAccion>\n' \
+                       '        </DatosSolicitud>\n'
 
+        m101_no_text_xml = M1(self.xml_m101.read().replace(text_to_elim, ''))
+        m101_no_text_xml.set_xsd()
+        m101_no_text_xml.parse_xml(validate=False)
+
+        assert m101_no_text_xml.sollicitud is False
+
+    def test_accept_no_contracte(self):
+        text_to_elim = '        <Contrato>\n' \
+                       '            <IdContrato>\n' \
+                       '                <CodContrato>' \
+                                            '111111111</CodContrato>\n' \
+                       '            </IdContrato>\n' \
+                       '            <Duracion>12</Duracion>\n' \
+                       '            <TipoContratoATR>01</TipoContratoATR>\n' \
+                       '            <CondicionesContractuales>\n' \
+                       '                <TarifaATR>001</TarifaATR>\n' \
+                       '                <PotenciasContratadas>\n' \
+                       '                    <Potencia Periodo="1">' \
+                                                '4400</Potencia>\n' \
+                       '                </PotenciasContratadas>\n' \
+                       '            </CondicionesContractuales>\n' \
+                       '            <DireccionCorrespondencia>\n' \
+                       '                <Indicador>S</Indicador>\n' \
+                       '            </DireccionCorrespondencia>\n' \
+                       '        </Contrato>\n'
+
+        m101_no_text_xml = M1(
+            self.xml_m101.read().replace(text_to_elim, ''))
+        m101_no_text_xml.set_xsd()
+        m101_no_text_xml.parse_xml(validate=False)
+
+        assert m101_no_text_xml.contracte is False
+
+    def test_accept_no_client(self):
+        text_to_elim = '        <Cliente>\n' \
+                       '            <IdCliente>\n' \
+                       '                <TipoCIFNIF>DN</TipoCIFNIF>\n' \
+                       '                <Identificador>' \
+                                            '11111111H</Identificador>\n' \
+                       '            </IdCliente>\n' \
+                       '            <Nombre>\n' \
+                       '                <NombreDePila>Perico</NombreDePila>\n' \
+                       '                <PrimerApellido>' \
+                                            'Palote</PrimerApellido>\n' \
+                       '                <SegundoApellido>' \
+                                            'Pérez</SegundoApellido>\n' \
+                       '            </Nombre>\n' \
+                       '            <Fax>\n' \
+                       '                <PrefijoPais>34</PrefijoPais>\n' \
+                       '                <Numero>555124124</Numero>\n' \
+                       '            </Fax>\n' \
+                       '            <Telefono>\n' \
+                       '                <PrefijoPais>34</PrefijoPais>\n' \
+                       '                <Numero>555123123</Numero>\n' \
+                       '            </Telefono>\n' \
+                       '            <IndicadorTipoDireccion>' \
+                                        'S</IndicadorTipoDireccion>\n' \
+                       '        </Cliente>\n'
+
+        m101_no_text_xml = M1(
+            self.xml_m101.read().replace(text_to_elim, ''))
+        m101_no_text_xml.set_xsd()
+        m101_no_text_xml.parse_xml(validate=False)
+
+        assert m101_no_text_xml.client is False
+
+    def test_accept_no_id_type(self):
+        text_to_elim = '        <TipoCIFNIF>DN</TipoCIFNIF>\n'
+
+        m101_no_text_xml = M1(
+            self.xml_m101.read().replace(text_to_elim, ''))
+        m101_no_text_xml.set_xsd()
+        m101_no_text_xml.parse_xml(validate=False)
+
+        assert m101_no_text_xml.client.tipus_identificacio == ''
+
+    def test_accept_no_cond_cont(self):
+        text_to_elim = '            <CondicionesContractuales>\n' \
+                       '                <TarifaATR>001</TarifaATR>\n' \
+                       '                <PotenciasContratadas>\n' \
+                       '                    <Potencia Periodo="1">' \
+                                                '4400</Potencia>\n' \
+                       '                </PotenciasContratadas>\n' \
+                       '            </CondicionesContractuales>\n'
+
+        m101_no_text_xml = M1(
+            self.xml_m101.read().replace(text_to_elim, ''))
+        m101_no_text_xml.set_xsd()
+        m101_no_text_xml.parse_xml(validate=False)
+
+        assert m101_no_text_xml.contracte.condicions is False
 
 
 class SwitchingR1_Test(unittest.TestCase):
@@ -2441,6 +2822,53 @@ class SwitchingR1_Test(unittest.TestCase):
         assert dades_retipificacio.tipus == '02'
         assert dades_retipificacio.subtipus == '03'
         assert dades_retipificacio.descripcio_retipificacio == 'descripcio de la retipificacio.'
+
+    def test_accept_no_sollicitud(self):
+        text_to_elim = '        <DatosSolicitud>\n' \
+                       '            <Tipo>03</Tipo>\n' \
+                       '            <Subtipo>16</Subtipo>\n' \
+                       '        </DatosSolicitud>\n'
+
+        r101_no_text_xml = R1(
+            self.xml_r101_minim.read().replace(text_to_elim, '')
+        )
+        r101_no_text_xml.set_xsd()
+        r101_no_text_xml.parse_xml(validate=False)
+
+        assert r101_no_text_xml.sollicitud is False
+
+    def test_accept_no_reclamacions(self):
+        text_to_elim = '        <VariablesDetalleReclamacion>\n' \
+                       '            <VariableDetalleReclamacion/>\n' \
+                       '        </VariablesDetalleReclamacion>\n'
+
+        r101_no_text_xml = R1(
+            self.xml_r101_minim.read().replace(text_to_elim, '')
+        )
+        r101_no_text_xml.set_xsd()
+        r101_no_text_xml.parse_xml(validate=False)
+
+        assert r101_no_text_xml.reclamacions == []
+
+    def test_accept_no_id_type(self):
+        text_to_elim = '        <TipoReclamante>06</TipoReclamante>\n'
+
+        r101_no_text_xml = R1(
+            self.xml_r101_minim.read().replace(text_to_elim, ''))
+        r101_no_text_xml.set_xsd()
+        r101_no_text_xml.parse_xml(validate=False)
+
+        assert r101_no_text_xml.tipus_reclamant == ''
+
+    def test_accept_no_cond_cont(self):
+        text_to_elim = '        <Comentarios>R1-01 minimum Test</Comentarios>\n'
+
+        r101_no_text_xml = R1(
+            self.xml_r101_minim.read().replace(text_to_elim, ''))
+        r101_no_text_xml.set_xsd()
+        r101_no_text_xml.parse_xml(validate=False)
+
+        assert r101_no_text_xml.comentaris == ''
 
 
 class SwitchingParseValidate(unittest.TestCase):


### PR DESCRIPTION
Now when you parse without validation and try to access fields that do not exist you simply get a False or a '' but it doesn't send an error.