### PR TITLE
IMP Drop ms in deadline dates

### DIFF
--- a/switching/input/messages/Deadlines.py
+++ b/switching/input/messages/Deadlines.py
@@ -7,6 +7,8 @@ class DeadLine(namedtuple('Deadline', "step, days, next_step")):
     def limit(self, date=None):
         if not date:
             date = datetime.today()
+        # cut microseconds
+        date = date.replace(microsecond=0)
         if isinstance(self.days, Naturaldays):
             return date + timedelta(self.days)
         else:


### PR DESCRIPTION
Drop milliseconds from returned deadline. Not necessary and adds problems to OpenERP